### PR TITLE
clean up: simplify MPDefaultFloorSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ class MapWidgetState extends State<MapWidget> {
                 // Add the MapsIndoors Widget to your Widget, it will automatically fill the container it is placed in.
                 child: _mapController = MapsIndoorsWidget(
                     // pass the floor selector controller
-                    floorSelector: _floorSelectorController,
+                    floorSelectorController: _floorSelectorController,
                     // set an optional starting location for the camera, this starts the camera above Los Angeles
                     initialCameraPosition: MPCameraPosition(zoom: 7, MPPoint.withCoordinates(longitude: -118.0165, latitude: 33.9457))
                     readyListener: _mapControlReadyListener,

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This section has examples of code for the following tasks:
 
 This snippet shows how to set up `MapsIndoors` in a Flutter application. First, the `MapsIndoorsWidget` is added to the application's build tree.
 
-Optionally we can add a `MPFloorSelector` to the map. Here we use `MPDefaultFloorSelector` as it is provided with the MapsIndoors package. The selector must be added both to the build tree as well as to `MapControl` in order to function correctly.
+Optionally we can add a floor selector to the map. Here we use `MPDefaultFloorSelector` with `MPDefaultFloorSelectorController` as provided with the MapsIndoors package. The controller is passed to `MapControl` and the widget is added to the build tree.
 
 Once `initState()` has been called, `MapsIndoors` begins initialization, and once that is done successfully, `MapControl` begins initialization.
 
@@ -136,8 +136,8 @@ class MapWidget extends StatefulWidget {
 }
 
 class MapWidgetState extends State<MapWidget> {
-    // Let's build a floor selector widget here, we need to add this to MapControl later.
-    final _floorSelectorWidget = MPDefaultFloorSelector();
+    // Create a floor selector controller
+    final _floorSelectorController = MPDefaultFloorSelectorController();
     // MapControl will be initialized after MapsIndoors.
     late final MapsIndoorsWidget _mapController;
 ​
@@ -147,8 +147,8 @@ class MapWidgetState extends State<MapWidget> {
             body: Container(
                 // Add the MapsIndoors Widget to your Widget, it will automatically fill the container it is placed in.
                 child: _mapController = MapsIndoorsWidget(
-                    // build with the default floor selector, this is optional.
-                    floorSelector: _floorSelectorWidget,
+                    // pass the floor selector controller
+                    floorSelector: _floorSelectorController,
                     // set an optional starting location for the camera, this starts the camera above Los Angeles
                     initialCameraPosition: MPCameraPosition(zoom: 7, MPPoint.withCoordinates(longitude: -118.0165, latitude: 33.9457))
                     readyListener: _mapControlReadyListener,

--- a/lib/core/mapsindoors_widget.dart
+++ b/lib/core/mapsindoors_widget.dart
@@ -417,7 +417,8 @@ class _MapsIndoorsState extends State<MapsIndoorsWidget> {
           jsonEncode(widget.initialCameraPosition?.toJson()),
     };
 
-    final floorSelector = widget.floorSelector ?? MPDefaultFloorSelector();
+    final floorSelector =
+        widget.floorSelector ?? const MPDefaultFloorSelector();
     if (Platform.isAndroid) {
       MapcontrolPlatform.instance.setFloorSelector(floorSelector, true);
     } else if (Platform.isIOS) {

--- a/lib/core/mapsindoors_widget.dart
+++ b/lib/core/mapsindoors_widget.dart
@@ -2,7 +2,7 @@ part of '../mapsindoors.dart';
 
 /// A [UniqueWidget] that contains the map used by MapsIndoors
 class MapsIndoorsWidget extends UniqueWidget {
-  final MPFloorSelectorInterface? floorSelector;
+  final MPFloorSelectorInterface? floorSelectorController;
   final MPMapLabelFont? mapLabelFont;
   final int? textSize;
   final bool? showFloorSelector;
@@ -37,7 +37,7 @@ class MapsIndoorsWidget extends UniqueWidget {
     this.buildingSelectionMode,
     this.floorSelectionMode,
     this.mapsIndoorsTransitionLevel,
-    this.floorSelector,
+    this.floorSelectorController,
     this.floorSelectorAlignment,
     this.readyListener,
     this.initialCameraPosition,
@@ -396,14 +396,14 @@ class _MapsIndoorsState extends State<MapsIndoorsWidget> {
   @override
   void initState() {
     super.initState();
-    if (widget.floorSelector == null) {
+    if (widget.floorSelectorController == null) {
       // Create a default floor selector controller and widget
       final controller = MPDefaultFloorSelectorController();
       _floorSelector = controller;
       _floorSelectorWidget = MPDefaultFloorSelector(controller: controller);
     } else {
-      _floorSelector = widget.floorSelector;
-      _floorSelectorWidget = widget.floorSelector!.getWidget();
+      _floorSelector = widget.floorSelectorController;
+      _floorSelectorWidget = widget.floorSelectorController!.getWidget();
     }
   }
 

--- a/lib/core/mapsindoors_widget.dart
+++ b/lib/core/mapsindoors_widget.dart
@@ -417,8 +417,7 @@ class _MapsIndoorsState extends State<MapsIndoorsWidget> {
           jsonEncode(widget.initialCameraPosition?.toJson()),
     };
 
-    final floorSelector =
-        widget.floorSelector ?? const MPDefaultFloorSelector();
+    final floorSelector = widget.floorSelector ?? MPDefaultFloorSelector();
     if (Platform.isAndroid) {
       MapcontrolPlatform.instance.setFloorSelector(floorSelector, true);
     } else if (Platform.isIOS) {

--- a/lib/core/mapsindoors_widget.dart
+++ b/lib/core/mapsindoors_widget.dart
@@ -2,7 +2,7 @@ part of '../mapsindoors.dart';
 
 /// A [UniqueWidget] that contains the map used by MapsIndoors
 class MapsIndoorsWidget extends UniqueWidget {
-  final MPFloorSelector? floorSelector;
+  final MPFloorSelectorInterface? floorSelector;
   final MPMapLabelFont? mapLabelFont;
   final int? textSize;
   final bool? showFloorSelector;
@@ -22,7 +22,7 @@ class MapsIndoorsWidget extends UniqueWidget {
   /// * Android
   /// * iOS
   ///
-  /// Has optional [MPFloorSelector] widget. Package includes a [MPDefaultFloorSelector].
+  /// Has optional [MPFloorSelectorInterface]. Package includes a [MPDefaultFloorSelector] and [MPDefaultFloorSelectorController].
   ///
   /// [mapStyleUri] When using Mapbox this can be set to use a custom Mapbox style. this setting is ignored if [useDefaultMapsIndoorsStyle] is not disabled.
   ///
@@ -389,6 +389,24 @@ class MapsIndoorsWidget extends UniqueWidget {
 }
 
 class _MapsIndoorsState extends State<MapsIndoorsWidget> {
+  // Create a default floor selector controller if none is provided
+  MPFloorSelectorInterface? _floorSelector;
+  Widget? _floorSelectorWidget;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.floorSelector == null) {
+      // Create a default floor selector controller and widget
+      final controller = MPDefaultFloorSelectorController();
+      _floorSelector = controller;
+      _floorSelectorWidget = MPDefaultFloorSelector(controller: controller);
+    } else {
+      _floorSelector = widget.floorSelector;
+      _floorSelectorWidget = widget.floorSelector!.getWidget();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // This is used in the platform side to register the view.
@@ -412,16 +430,15 @@ class _MapsIndoorsState extends State<MapsIndoorsWidget> {
         "mapStyleUri": widget.mapStyleUri,
       }),
       "floorSelectorAutoFloorChange":
-          widget.floorSelector?.isAutoFloorChangeEnabled == true,
+          _floorSelector?.isAutoFloorChangeEnabled == true,
       "initialCameraPosition":
           jsonEncode(widget.initialCameraPosition?.toJson()),
     };
 
-    final floorSelector = widget.floorSelector ?? MPDefaultFloorSelector();
     if (Platform.isAndroid) {
-      MapcontrolPlatform.instance.setFloorSelector(floorSelector, true);
+      MapcontrolPlatform.instance.setFloorSelector(_floorSelector!, true);
     } else if (Platform.isIOS) {
-      MapcontrolPlatform.instance.setFloorSelector(floorSelector, false);
+      MapcontrolPlatform.instance.setFloorSelector(_floorSelector!, false);
     }
     final StatefulWidget miView;
 
@@ -466,10 +483,11 @@ class _MapsIndoorsState extends State<MapsIndoorsWidget> {
       flex: 1,
       child: Stack(children: [
         miView,
-        Align(
-          alignment: widget.floorSelectorAlignment ?? Alignment.centerRight,
-          child: floorSelector,
-        )
+        if (_floorSelectorWidget != null)
+          Align(
+            alignment: widget.floorSelectorAlignment ?? Alignment.centerRight,
+            child: _floorSelectorWidget!,
+          )
       ]),
     );
   }

--- a/lib/core/mp_default_floor_selector.dart
+++ b/lib/core/mp_default_floor_selector.dart
@@ -3,11 +3,6 @@ part of '../mapsindoors.dart';
 class MPDefaultFloorSelector extends StatefulWidget with MPFloorSelector {
   const MPDefaultFloorSelector({super.key});
 
-  static _MPDefaultFloorSelectorState? _currentState;
-  static List<MPFloor>? _pendingFloors;
-  static OnFloorSelectionChangedListener? _pendingListener;
-  static int? _pendingUserPositionFloor;
-
   @override
   Widget? getWidget() => this;
 
@@ -16,49 +11,54 @@ class MPDefaultFloorSelector extends StatefulWidget with MPFloorSelector {
 
   @override
   set floors(List<MPFloor>? value) {
-    if (_currentState == null) {
-      _pendingFloors = value;
-    } else {
-      _currentState!.floors = value;
-    }
+    // Find the current state using the widget's key
+    final state = _findCurrentState();
+    state?.floors = value;
   }
 
   @override
   set onFloorSelectionChangedListener(OnFloorSelectionChangedListener value) {
-    if (_currentState == null) {
-      _pendingListener = value;
-    } else {
-      _currentState!.onFloorSelectionChangedListener = value;
-    }
+    final state = _findCurrentState();
+    state?.onFloorSelectionChangedListener = value;
   }
 
   @override
   void setSelectedFloor(MPFloor floor) {
-    _currentState?.setSelectedFloor(floor);
+    final state = _findCurrentState();
+    state?.setSelectedFloor(floor);
   }
 
   @override
   void setSelectedFloorByFloorIndex(int floorIndex) {
-    _currentState?.setSelectedFloorByFloorIndex(floorIndex);
+    final state = _findCurrentState();
+    state?.setSelectedFloorByFloorIndex(floorIndex);
   }
 
   @override
   set userPositionFloor(int value) {
-    if (_currentState == null) {
-      _pendingUserPositionFloor = value;
-    } else {
-      _currentState!.userPositionFloor = value;
-    }
+    final state = _findCurrentState();
+    state?.userPositionFloor = value;
   }
 
   @override
   void show(bool show) {
-    _currentState?.show(show);
+    final state = _findCurrentState();
+    state?.show(show);
   }
 
   @override
   void zoomLevelChanged(num newZoomLevel) {
-    _currentState?.zoomLevelChanged(newZoomLevel);
+    final state = _findCurrentState();
+    state?.zoomLevelChanged(newZoomLevel);
+  }
+
+  /// Safely finds the current state instance via the widget's [GlobalKey].
+  _MPDefaultFloorSelectorState? _findCurrentState() {
+    final state = (key as GlobalKey?)?.currentState;
+    if (state is _MPDefaultFloorSelectorState) {
+      return state;
+    }
+    return null;
   }
 
   @override
@@ -77,29 +77,10 @@ class _MPDefaultFloorSelectorState extends State<MPDefaultFloorSelector>
   @override
   void initState() {
     super.initState();
-    MPDefaultFloorSelector._currentState = this;
-
-    // Handle any pending values
-    if (MPDefaultFloorSelector._pendingFloors != null) {
-      floors = MPDefaultFloorSelector._pendingFloors;
-      MPDefaultFloorSelector._pendingFloors = null;
-    }
-    if (MPDefaultFloorSelector._pendingListener != null) {
-      onFloorSelectionChangedListener =
-          MPDefaultFloorSelector._pendingListener!;
-      MPDefaultFloorSelector._pendingListener = null;
-    }
-    if (MPDefaultFloorSelector._pendingUserPositionFloor != null) {
-      userPositionFloor = MPDefaultFloorSelector._pendingUserPositionFloor!;
-      MPDefaultFloorSelector._pendingUserPositionFloor = null;
-    }
   }
 
   @override
   void dispose() {
-    if (MPDefaultFloorSelector._currentState == this) {
-      MPDefaultFloorSelector._currentState = null;
-    }
     super.dispose();
   }
 

--- a/lib/core/mp_floor_selector.dart
+++ b/lib/core/mp_floor_selector.dart
@@ -1,3 +1,0 @@
-part of '../mapsindoors.dart';
-
-mixin MPFloorSelector on Widget implements MPFloorSelectorInterface {}

--- a/lib/mapsindoors.dart
+++ b/lib/mapsindoors.dart
@@ -96,6 +96,5 @@ part 'core/mapsindoors_widget.dart';
 part 'core/mp_directions_service.dart';
 part 'core/mp_directions_renderer.dart';
 part 'core/mp_default_floor_selector.dart';
-part 'core/mp_floor_selector.dart';
 part 'core/mp_map_label_font.dart';
 part 'core/mapsindoors.dart';


### PR DESCRIPTION
Hi MapsPeople team! Thank you so much for this great Flutter SDK. As we were working on building a custom floor selector widget, we came up with some ideas to clean up the `MPDefaultFloorSelector` widget provided by this SDK. We feel that this updated code is a bit easier to understand and more idiomatic Dart. But, it is a breaking change. We're looking forward to hearing your thoughts!